### PR TITLE
ActivePython version includes build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # python-on-coreos
-Python on CoreOS. works well with ansible.
+Python on CoreOS.
 
-this script install Active Python x86_64 binary to CoreOS.
-this will works well with ansible, also any 3rd party software. because it hsa pip also. :)
+this script installs Active Python x86_64 binary to CoreOS.
+this works well with ansible and any 3rd party software because it also has pip. :)
 
 INSTALL
 =======
@@ -15,19 +15,9 @@ wget -qO- https://raw.githubusercontent.com/ziozzang/python-on-coreos/master/ins
 RUNNING
 =======
 
-/opt/bin/python will works well. :)
+/opt/bin/python works well. :)
 
-if you want to run python in anywhere, just make ~/.bashrc file which contains this.
-```
-export PATH=$PATH:/opt/bin
-```
-
-or just run this command
-```
-cat > ~/.bashrc << EOF
-export PATH=\$PATH:/opt/bin
-EOF
-```
+recent CoreOS already puts /opt/bin in $PATH.
 
 
 WITH ANSIBLE

--- a/install-python-on-coreos.sh
+++ b/install-python-on-coreos.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-VERSIONS=${VERSIONS:-"2.7.8.10"}
+VERSION=${VERSION:-"2.7.13.2715-linux-x86_64-glibc-2.12-402695"}
 
 # make directory
 mkdir -p /opt/bin
 cd /opt
 
-wget http://downloads.activestate.com/ActivePython/releases/${VERSIONS}/ActivePython-${VERSIONS}-linux-x86_64.tar.gz
-tar -xzvf ActivePython-${VERSIONS}-linux-x86_64.tar.gz
+wget -qO - http://downloads.activestate.com/ActivePython/releases/${VERSION%%-*}/ActivePython-${VERSION}.tar.gz | tar -xzvf -
 
-mv ActivePython-${VERSIONS}-linux-x86_64 apy && cd apy && ./install.sh -I /opt/python/
+(cd ActivePython-${VERSION} && ./install.sh -I /opt/python/)
+rm -rf ActivePython-${VERSION}
 
-ln -s /opt/python/bin/easy_install /opt/bin/easy_install
-ln -s /opt/python/bin/pip /opt/bin/pip
-ln -s /opt/python/bin/python /opt/bin/python
-ln -s /opt/python/bin/virtualenv /opt/bin/virtualenv
+ln -sf /opt/python/bin/easy_install /opt/bin/easy_install
+ln -sf /opt/python/bin/pip /opt/bin/pip
+ln -sf /opt/python/bin/python /opt/bin/python
+ln -sf /opt/python/bin/virtualenv /opt/bin/virtualenv

--- a/sample-ansible-hosts
+++ b/sample-ansible-hosts
@@ -5,7 +5,6 @@ core-01
 
 [coreos:vars]
 ansible_ssh_user=core
-ansible_python_interpreter="PATH=/opt/bin:$PATH python"
 
 # you can run command just like this..
 # ansible -m setup -i hosts core-01


### PR DESCRIPTION
recent CoreOS already puts /opt/bin in $PATH
clean up detritus