### PR TITLE
Add pip package binaries into path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ RUNNING
 
 if you want to run python in anywhere, just make ~/.bashrc file which contains this.
 ```
-export PATH=$PATH:/opt/bin
+export PATH=$PATH:/opt/bin:/opt/python/bin
 ```
 
 or just run this command
 ```
 cat > ~/.bashrc << EOF
-export PATH=\$PATH:/opt/bin
+export PATH=\$PATH:/opt/bin:/opt/python/bin
 EOF
 ```
 

--- a/sample-ansible-hosts
+++ b/sample-ansible-hosts
@@ -5,7 +5,7 @@ core-01
 
 [coreos:vars]
 ansible_ssh_user=core
-ansible_python_interpreter="PATH=/opt/bin:$PATH python"
+ansible_python_interpreter="PATH=/opt/bin:/opt/python/bin:$PATH python"
 
 # you can run command just like this..
 # ansible -m setup -i hosts core-01


### PR DESCRIPTION
Any package installed by pip is not globally available since pip package's binaries are residing in /opt/python/bin which is not in path by default. This PR fixes it, therefore making fully functional python environment in Core OS.

Tested on: Core OS 1855.4.0 (stable)